### PR TITLE
Add Clickable Link if automatic redirect fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,23 +47,22 @@
   <footer>
 
     <script>
-        'use strict';
-        const urlParams = new URLSearchParams(window.location.search);
-        const redirect_url = decodeURIComponent(urlParams.get('state'));
-        const code = urlParams.get('code');
-        const validOrigin = document.referrer?.includes('spotify.com');
-        const validDest = redirect_url?.includes(':') && redirect_url?.includes('/callback/');
+      'use strict';
+      const urlParams = new URLSearchParams(window.location.search);
+      const redirect_url = decodeURIComponent(urlParams.get('state'));
+      const validOrigin = document.referrer?.includes('spotify.com');
+      const validDest = redirect_url.includes(':') && redirect_url.includes('/callback/');
 
-        const finalUrl = redirect_url + '?code=' + code;
+      const finalUrl = redirect_url + '?code=' + code;
 
-        if (validOrigin && validDest) {
-            window.location.replace(finalUrl);
-        } else {
-            // Show manual link if automatic redirect doesn't work
-            document.getElementById('manual-link').style.display = 'block';
-            const linkElement = document.getElementById('redirect-link');
-            linkElement.href = finalUrl;
-        }
+      if (validOrigin && validDest) {
+        window.location.replace(finalUrl);
+      } else {
+        // Show manual link if automatic redirect doesn't work
+        document.getElementById('manual-link').style.display = 'block';
+        const linkElement = document.getElementById('redirect-link');
+        linkElement.href = finalUrl;
+      }
     </script>
   </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
         </div>
     </div>
 
+  <footer>
+
     <script>
         'use strict';
         const urlParams = new URLSearchParams(window.location.search);
@@ -63,5 +65,6 @@
             linkElement.href = finalUrl;
         }
     </script>
+  </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,26 +1,67 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Music Assistant oAuth Redirect</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f0f0f0;
+        }
+        .container {
+            text-align: center;
+            background-color: white;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        #manual-link {
+            display: none;
+            margin-top: 1rem;
+        }
+        a {
+            color: #1DB954;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
 </head>
-
 <body>
-
-  Music Assistant oAuth Redirect page.
-
-  <footer>
+    <div class="container">
+        <h1>Music Assistant oAuth Redirect</h1>
+        <p>Processing your request...</p>
+        <div id="manual-link">
+            <p>If you are not redirected automatically, please click the link below:</p>
+            <a href="#" id="redirect-link">Complete Authentication</a>
+        </div>
+    </div>
 
     <script>
-      'use strict';
-      const urlParams = new URLSearchParams(window.location.search);
-      const redirect_url = decodeURIComponent(urlParams.get('state'));
-      const validOrigin = document.referrer?.includes('spotify.com');
-      const validDest = redirect_url.includes(':') && redirect_url.includes('/callback/');
-      if (validOrigin && validDest)
-      {
-        window.location.replace(redirect_url + '?code=' + urlParams.get('code'));
-      }
+        'use strict';
+        const urlParams = new URLSearchParams(window.location.search);
+        const redirect_url = decodeURIComponent(urlParams.get('state'));
+        const code = urlParams.get('code');
+        const validOrigin = document.referrer?.includes('spotify.com');
+        const validDest = redirect_url?.includes(':') && redirect_url?.includes('/callback/');
+
+        const finalUrl = redirect_url + '?code=' + code;
+
+        if (validOrigin && validDest) {
+            window.location.replace(finalUrl);
+        } else {
+            // Show manual link if automatic redirect doesn't work
+            document.getElementById('manual-link').style.display = 'block';
+            const linkElement = document.getElementById('redirect-link');
+            linkElement.href = finalUrl;
+        }
     </script>
-  </footer>
 </body>
 </html>


### PR DESCRIPTION
in Safari the document.referrer is empty. Thus the `const validOrigin` is false and I'm stuck on an empty page with the text "Music Assistant oAuth Redirect page."

this pull request adds a simple banner with a clickable link containing of the URL that should have been used in the automatic redirect.

<img width="601" alt="Bildschirmfoto 2024-09-20 um 15 57 03" src="https://github.com/user-attachments/assets/0374a4c0-838f-4076-9f8d-80df5673ee72">
